### PR TITLE
Wait for service worker to start before doing anything else

### DIFF
--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -144,7 +144,6 @@ export class Platform {
         this._serviceWorkerHandler = null;
         if (assetPaths.serviceWorker && "serviceWorker" in navigator) {
             this._serviceWorkerHandler = new ServiceWorkerHandler();
-            this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
         this.notificationService = undefined;
         // Only try to use crypto when olm is provided
@@ -172,6 +171,12 @@ export class Platform {
 
     async init() {
         try {
+            if (this._serviceWorkerHandler instanceof ServiceWorkerHandler) {
+                // Start the service worker before doing anything else,
+                // to make sure all requests are intercepted by the service worker.
+                await this._serviceWorkerHandler.registerAndStart(this._assetPaths.serviceWorker)
+            }
+
             await this.logger.run("Platform init", async (log) => {
                 if (!this._config) {
                     if (!this._configURL) {

--- a/src/platform/web/dom/ServiceWorkerHandler.js
+++ b/src/platform/web/dom/ServiceWorkerHandler.js
@@ -33,8 +33,8 @@ export class ServiceWorkerHandler {
         this._navigation = navigation;
     }
 
-    registerAndStart(path) {
-        this._registrationPromise = (async () => {
+    async registerAndStart(path) {
+        return this._registrationPromise = (async () => {
             navigator.serviceWorker.addEventListener("message", this);
             navigator.serviceWorker.addEventListener("controllerchange", this);
             this._registration = await navigator.serviceWorker.register(path);


### PR DESCRIPTION
To make sure all requests are intercepted by the service worker, I think hydrogen should only boot once the service worker has started. 