### PR TITLE
Proposal: Sync in worker

### DIFF
--- a/doc/implementation planning/sync-in-worker.md
+++ b/doc/implementation planning/sync-in-worker.md
@@ -1,0 +1,119 @@
+# Sync in worker
+Currently, it's not possible to have the same session open in multiple Hydrogen instances (i.e. in multiple tabs, windows or iframes) since this would result in having multiple ongoing syncs for the same session. Having multiple ongoing syncs could corrupt data in `indexedDB` and would also not make sense from a resource utilisation perspective.
+
+To prevent that multiple syncs are ongoing for the same session, a session-closing mechanism is implemented in the service worker: when a session is opened in an instance, the service worker tells all other instances to close that session, if they have it open.
+
+From the user's perspective, this results in Hydrogen going back to the session picker screen when the session that was open in one tab is opened in another tab.
+
+In this document, we propose a solution to address this limitation, making it possible to have the same session simultaneously open in multiple Hydrogen instances, while maintaining a fully-featured experience for the user.
+
+This proposal would also pave the way for having simultaneous ongoing syncs for multiple sessions (i.e. multiple accounts) in the future, though that's not a use case we would focus on at this point.
+
+## Offload sync to worker
+
+The general idea would be to have sync running in a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) instead of the main thread, while making it **transparent to UI code** (i.e. code running in the main thread), which should not be aware of whether sync is running in a worker or in the main thread. Making it transparent to UI code is important since we need to fallback to non-worker sync in environments where Web Workers are not available (e.g. IE11).
+
+Since we don't want to tie the lifetime of the sync worker to a specific tab/window (we want the sync to happen for as long as there's at least one instance with that session open), the sync worker would be *owned* by the service worker. Note that this doesn't mean that the service worker would run the sync, but that it would spawn another worker dedicated to the sync.
+
+The UI thread would communicate with the sync worker through messages, possibly leveraging [`BroadcastChannel`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
+
+We would be making the changes behind a feature flag, which would allows us to spread the implementation across multiple PRs, and iterate on the feature until we're confident that it's stable.
+
+## `SyncProxy` (UI side)
+
+`SyncProxy` would be the equivalent of `Sync` but would be a thin layer that *proxies* method calls to the worker, something like the following:
+
+```typescript
+// SyncProxy.ts
+
+// Here we're extending Sync but it would make more sense to extract an ISync
+// interface that both Sync and SyncProxy implement.
+export class SyncProxy extends Sync {
+    // Not a full implementation, just showcasing a method call.
+    // In the final implementation all public methods of Sync would need to
+    // be proxied.
+    async start(args: object): Promise<object> {
+        const result = await sendAndWaitForReply("start", args);
+        if (result.error) {
+            throw result.error;
+        }
+        return result.data;
+    }
+}
+```
+
+In environments where Web Workers are available, and if the feature flag is enabled, we would *swap* `Sync` with `SyncProxy`:
+
+```javascript
+// Client.js
+
+if (window.Worker && syncFeatureFlagEnabled) {
+    this._sync = new SyncProxy({...});
+} else {
+    this._sync = new Sync({...});
+}
+```
+
+## `SyncWorker` (Worker side)
+
+The sync worker would react to incoming messages, and perform different actions according to the type of message. For example, when receiving the `start` message, the worker would bootstrap an instance of `Sync` and start it:
+
+```typescript
+
+// SyncInWorker.ts
+export class SyncInWorker extends Sync {
+    // The need for this class will become clear in the next section.
+}
+
+// SyncWorker.ts
+export class SyncWorker {
+    // ...
+
+    async onStartMessage(sessionId: string): Promise<object> {
+        this._sync = new SyncInWorker({...});
+        this._sync.start();
+
+        // This would result in a reply being sent to `SyncProxy` running in
+        // the main thread.
+        return {started: true};
+    }
+}
+```
+
+## Communicating *side effects* of sync
+
+The sync process happens roughly as follows:
+
+1. Persist data to `indexedDB`.
+2. Update `Session` in memory so it reflects the latest changes.
+
+Since workers do not share memory with the main thread, the sync worker will have its own instance of `Session`, so changes to it will not be reflected in the main thread's `Session`. So we need a mechanism to update the main thread's `Session` whenever there have been sync changes.
+
+We would do this by having the sync worker send messages to `SyncProxy` notifying of changes, and the `SyncProxy` would update the main thread's instance of `Session`:
+
+```typescript
+// SyncInWorker.ts
+
+export class SyncInWorker extends Sync {
+    // ...
+
+    // Override base class method.
+    _afterSync(sessionState, inviteStates, roomStates, archivedRoomStates, log) {
+        // Send message(s) representing the sync changes.
+        sendMessage("syncChanges", ...);
+    }
+}
+```
+
+```typescript
+// SyncProxy.ts
+
+export class SyncProxy extends Sync {
+    // ...
+
+    onChanges(data: object) {
+        const sessionState = data.sessionState;
+        this.session.foo = sessionState.bar;
+    }
+}
+```

--- a/doc/implementation planning/sync-in-worker.md
+++ b/doc/implementation planning/sync-in-worker.md
@@ -7,6 +7,8 @@ From the user's perspective, this results in Hydrogen going back to the session 
 
 In this document, we propose a solution to address this limitation, making it possible to have the same session simultaneously open in multiple Hydrogen instances, while maintaining a fully-featured experience for the user.
 
+We would be making the changes behind a feature flag, which would allows us to spread the implementation across multiple PRs, and iterate on the feature until we're confident that it's stable.
+
 This proposal would also pave the way for having simultaneous ongoing syncs for multiple sessions (i.e. multiple accounts) in the future, though that's not a use case we would focus on at this point.
 
 ## Offload sync to worker
@@ -16,8 +18,6 @@ The general idea would be to have sync running in a [Web Worker](https://develop
 Since we don't want to tie the lifetime of the sync worker to a specific tab/window (we want the sync to happen for as long as there's at least one instance with that session open), the sync worker would be *owned* by the service worker. Note that this doesn't mean that the service worker would run the sync, but that it would spawn another worker dedicated to the sync.
 
 The UI thread would communicate with the sync worker through messages, possibly leveraging [`BroadcastChannel`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
-
-We would be making the changes behind a feature flag, which would allows us to spread the implementation across multiple PRs, and iterate on the feature until we're confident that it's stable.
 
 ## `SyncProxy` (UI side)
 

--- a/doc/implementation planning/sync-in-worker.md
+++ b/doc/implementation planning/sync-in-worker.md
@@ -93,7 +93,7 @@ export class SyncWorker {
 }
 ```
 
-## Communicating *side effects* of sync
+## Propagating sync changes
 
 The sync process happens roughly as follows:
 
@@ -130,3 +130,6 @@ export class SyncProxy extends Sync {
     }
 }
 ```
+
+## No need to send changes from main thread to worker
+When an action happens in the main thread (sending a message, creating a room, etc), there is no need to communicate that change to the worker or other windows/tabs/iframe, as that change would be retrieved in the next sync, and then propagated as described in the previous section.


### PR DESCRIPTION
Addresses https://github.com/vector-im/hydrogen-web/issues/1045

This is a proposal for running sync in a worker, so that it would be possible to have the same session open in multiple tabs/windows/iframes.

[Rendered](https://github.com/vector-im/hydrogen-web/blob/ea19cf278842cfc870af08ae9d756e0135753867/doc/implementation%20planning/sync-in-worker.md)

## TODO

- [x] Clarify the lifetime and ownership of workers
    - [x] Take in account that service worker must remain optional
    - [x] Explore possibility of using `SharedWorker`
- [x] Clarify whether mutations to the `Session` in the main thread need to be communicated to the worker
- [x] Clarify how messages will be passed between main thread and worker, check browser support for `BroadcastChannel`.
- [x] Clarify whether there's a limit on the number of workers that can run at a given time
- [ ] Clarify the usage of `localStorage` in `Storage`, since `localStorage` is not available in workers
- [ ] Clarify "after sync" step
    - [ ] Some things should only be run once per sync
    - [ ] List of things that would need their updates passed over the message channel between the worker and the page

