### PR TITLE
Update code in RoomEncryption to use device_id and user_id

### DIFF
--- a/src/matrix/calls/group/Member.ts
+++ b/src/matrix/calls/group/Member.ts
@@ -183,6 +183,16 @@ export class Member {
         return this.callDeviceMembership.device_id;
     }
 
+    /** @internal, to emulate deviceKey properties when calling formatToDeviceMessagesPayload */   
+    get user_id(): string {
+        return this.userId;
+    }
+    
+    /** @internal, to emulate deviceKey properties when calling formatToDeviceMessagesPayload */
+    get device_id(): string {
+        return this.deviceId;
+    }
+
     /** session id of the member */
     get sessionId(): string {
         return this.callDeviceMembership.session_id;

--- a/src/matrix/common.js
+++ b/src/matrix/common.js
@@ -33,11 +33,11 @@ export function isTxnId(txnId) {
 }
 
 export function formatToDeviceMessagesPayload(messages) {
-    const messagesByUser = groupBy(messages, message => message.device.userId);
+    const messagesByUser = groupBy(messages, message => message.device.user_id);
     const payload = {
         messages: Array.from(messagesByUser.entries()).reduce((userMap, [userId, messages]) => {
             userMap[userId] = messages.reduce((deviceMap, message) => {
-                deviceMap[message.device.deviceId] = message.content;
+                deviceMap[message.device.device_id] = message.content;
                 return deviceMap;
             }, {});
             return userMap;

--- a/src/matrix/e2ee/RoomEncryption.js
+++ b/src/matrix/e2ee/RoomEncryption.js
@@ -353,7 +353,7 @@ export class RoomEncryption {
         this._historyVisibility = await this._loadHistoryVisibilityIfNeeded(this._historyVisibility);
         await this._deviceTracker.trackRoom(this._room, this._historyVisibility, log);
         const devices = await this._deviceTracker.devicesForTrackedRoom(this._room.id, hsApi, log);
-        const userIds = Array.from(devices.reduce((set, device) => set.add(device.userId), new Set()));
+        const userIds = Array.from(devices.reduce((set, device) => set.add(device.user_id), new Set()));
             
         let writeOpTxn = await this._storage.readWriteTxn([this._storage.storeNames.operations]);
         let operation;
@@ -431,8 +431,8 @@ export class RoomEncryption {
         await log.wrap("send", log => this._sendMessagesToDevices(ENCRYPTED_TYPE, messages, hsApi, log));
         if (missingDevices.length) {
             await log.wrap("missingDevices", async log => {
-                log.set("devices", missingDevices.map(d => d.deviceId));
-                const unsentUserIds = operation.userIds.filter(userId => missingDevices.some(d => d.userId === userId));
+                log.set("devices", missingDevices.map(d => d.device_id));
+                const unsentUserIds = operation.userIds.filter(userId => missingDevices.some(d => d.user_id === userId));
                 log.set("unsentUserIds", unsentUserIds);
                 operation.userIds = unsentUserIds;
                 // first remove the users that we've sent the keys already from the operation,
@@ -459,11 +459,11 @@ export class RoomEncryption {
 
     // TODO: make this use _sendMessagesToDevices
     async _sendSharedMessageToDevices(type, message, devices, hsApi, log) {
-        const devicesByUser = groupBy(devices, device => device.userId);
+        const devicesByUser = groupBy(devices, device => device.user_id);
         const payload = {
             messages: Array.from(devicesByUser.entries()).reduce((userMap, [userId, devices]) => {
                 userMap[userId] = devices.reduce((deviceMap, device) => {
-                    deviceMap[device.deviceId] = message;
+                    deviceMap[device.device_id] = message;
                     return deviceMap;
                 }, {});
                 return userMap;


### PR DESCRIPTION
Encrypted messages sent from Hydrogen now appear as UTDs in other clients. 