### PR TITLE
Add "😂" to list of quick reaction emojis

### DIFF
--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -138,7 +138,7 @@ class QuickReactionsMenuOption {
         this._vm = vm;
     }
     toDOM(t) {
-        const emojiButtons = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"].map(emoji => {
+        const emojiButtons = ["👍", "👎", "😂", "🎉", "😄", "😕", "❤️", "🚀", "👀"].map(emoji => {
             return t.button({onClick: () => this._vm.react(emoji)}, emoji);
         });
         const customButton = t.button({onClick: () => {


### PR DESCRIPTION
Unicode "face with tears of joy" is (one of) the most used emoji (https://emojipedia.org/face-with-tears-of-joy), so it makes sense to have it in the quick reaction list.

I use it a lot and it is annoying to always enter it manually.

I kept "😄" in the list because I thought that it was probably a conscious decision to have it in there instead of "😂" in the first place.

![color-after](https://github.com/user-attachments/assets/983fd130-bce1-4a29-bc49-a4372532b407)
