### PR TITLE
fix: Spaces can be sent as message

### DIFF
--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -95,6 +95,9 @@ export class MessageComposer extends TemplateView {
         // to prevent the user from sending the message
         // every time they hit enter while it's still enqueuing.
         const {value} = this._input;
+        if (!value || !value.trim()) {
+            return;
+        }
         const restoreValue = () => {
             this._input.value = value;
             this._adjustHeight();


### PR DESCRIPTION
This change prevents sending messages that are either empty or contain only whitespace. When a user tries to send such a message, the method will simply return without sending anything. 
Closes #1203 