### PR TITLE
Fix: Prevent crashes when updateService undefined

### DIFF
--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -283,7 +283,7 @@ export class Client {
         });
 
         // Let the serviceWorkerHandler know of this access-token and homeserver
-        this._platform.updateService.updateAuthData({
+        this._platform.updateService?.updateAuthData({
             accessToken: sessionInfo.accessToken,
             homeserver: sessionInfo.homeServer,
         });
@@ -377,7 +377,7 @@ export class Client {
             throw Error("No session loaded, cannot update access token");
         }
         this._session.updateAccessToken(token);
-        this._platform.updateService.updateAuthData({
+        this._platform.updateService?.updateAuthData({
             accessToken: token,
         });
         await this._platform.sessionInfoStorage.updateAccessToken(this._sessionId, token);


### PR DESCRIPTION
The updateService can be undefined when service workers are not available or not configured. This causes crashes when trying to call updateAuthData.

Add optional chaining (?.) to both updateService.updateAuthData calls in Client.js to prevent crashes in environments where service workers are not supported or configured.

Fixes crashes when updateService is undefined due to missing service worker configuration or unsupported browser environment.

Note: This bug has likely gone unnoticed because errors in the sync process are silently swallowed by empty catch blocks in Sync.js, making failures invisible.