### PR TITLE
Use dedicated subdomain for bug reporting

### DIFF
--- a/src/platform/types/config.ts
+++ b/src/platform/types/config.ts
@@ -15,7 +15,7 @@ export type Config = {
     defaultHomeServer: string;
     /**
      * The submit endpoint for your preferred rageshake server.
-     * eg: https://element.io/bugreports/submit
+     * eg: https://rageshakes.element.io/api/submit
      * Read more about rageshake at https://github.com/matrix-org/rageshake
      * OPTIONAL
      */

--- a/src/platform/web/assets/config.json
+++ b/src/platform/web/assets/config.json
@@ -5,5 +5,5 @@
     "applicationServerKey": "BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM"
   },
   "defaultHomeServer": "matrix.org",
-  "bugReportEndpointUrl": "https://element.io/bugreports/submit"
+  "bugReportEndpointUrl": "https://rageshakes.element.io/api/submit"
 }


### PR DESCRIPTION
There is a dedicated subdomain for Rageshakes, it should be used to avoid issues with element.io path routing